### PR TITLE
Improve cybozu::hash_map implementation.

### DIFF
--- a/cybozu/dynbuf.hpp
+++ b/cybozu/dynbuf.hpp
@@ -39,8 +39,13 @@ public:
             _free(m_p);
     }
     dynbuf(const dynbuf&) = delete;
+    dynbuf(dynbuf&& rhs) noexcept:
+        m_p(nullptr), m_default_capacity(rhs.m_default_capacity),
+        m_capacity(rhs.m_capacity), m_used(rhs.m_used)
+    {
+        std::swap(m_p, rhs.m_p);
+    }
     dynbuf& operator=(const dynbuf&) = delete;
-    dynbuf(dynbuf&&) noexcept = delete;
     dynbuf& operator=(dynbuf&&) = delete;
 
     void swap(dynbuf& other) noexcept {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -30,11 +30,18 @@ extern thread_local int g_context;
 //
 // This class represents an object in the hash table.
 // Large objects are stored in temporary files.
-class object {
+class object final {
 public:
     object(const char* p, std::size_t len,
            std::uint32_t flags_, std::time_t exptime);
     object(std::uint64_t initial, std::time_t exptime);
+    object(const object&) = delete;
+    object(object&& rhs) noexcept:
+        m_length(rhs.m_length), m_data(std::move(rhs.m_data)),
+        m_file(std::move(rhs.m_file)), m_flags(rhs.m_flags),
+        m_exptime(rhs.m_exptime), m_cas(rhs.m_cas) {}
+    object& operator=(const object&) = delete;
+    object& operator=(object&&) = delete;
 
     // Exception thrown by <incr> or <decr>.
     struct not_a_number: public std::runtime_error {

--- a/src/replication.cpp
+++ b/src/replication.cpp
@@ -95,12 +95,11 @@ std::size_t repl_recv(const char* p, std::size_t len,
                 obj.set(p2, len2, parser.flags(), parser.exptime());
                 return true;
             };
-            c = [&parser](const cybozu::hash_key&) -> std::unique_ptr<object> {
+            c = [&parser](const cybozu::hash_key&) -> object {
                 const char* p2;
                 std::size_t len2;
                 std::tie(p2, len2) = parser.data();
-                return std::unique_ptr<object>(
-                    new object(p2, len2, parser.flags(), parser.exptime()) );
+                return object(p2, len2, parser.flags(), parser.exptime());
             };
             std::tie(key_data, key_len) = parser.key();
             cybozu::logger::debug() << "repl: set "

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -148,17 +148,16 @@ inline void worker::exec_cmd_bin(const binary_request& cmd) {
         if( cmd.command() != binary_command::Replace &&
             cmd.command() != binary_command::ReplaceQ &&
             cmd.cas_unique() == 0 ) {
-            c = [this,&cmd,&r](const cybozu::hash_key& k) -> std::unique_ptr<object> {
+            c = [this,&cmd,&r](const cybozu::hash_key& k) -> object {
                 const char* p2;
                 std::size_t len2;
                 std::tie(p2, len2) = cmd.data();
-                auto t = std::unique_ptr<object>(
-                    new object(p2, len2, cmd.flags(), cmd.exptime()) );
+                object o(p2, len2, cmd.flags(), cmd.exptime());
                 if( ! cmd.quiet() )
-                    r.set( t->cas_unique() );
+                    r.set( o.cas_unique() );
                 if( ! m_slaves.empty() )
-                    repl_object(m_slaves, k, *t);
-                return std::move(t);
+                    repl_object(m_slaves, k, o);
+                return std::move(o);
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) ) {
@@ -295,14 +294,13 @@ inline void worker::exec_cmd_bin(const binary_request& cmd) {
             return true;
         };
         if( cmd.exptime() != binary_request::EXPTIME_NONE ) {
-            c = [this,&cmd,&r](const cybozu::hash_key& k) -> std::unique_ptr<object> {
-                auto t = std::unique_ptr<object>(
-                    new object(cmd.initial(), cmd.exptime()) );
+            c = [this,&cmd,&r](const cybozu::hash_key& k) -> object {
+                object o(cmd.initial(), cmd.exptime());
                 if( ! cmd.quiet() )
-                    r.incdec( cmd.initial(), t->cas_unique() );
+                    r.incdec( cmd.initial(), o.cas_unique() );
                 if( ! m_slaves.empty() )
-                    repl_object(m_slaves, k, *t);
-                return std::move(t);
+                    repl_object(m_slaves, k, o);
+                return std::move(o);
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) )
@@ -329,14 +327,13 @@ inline void worker::exec_cmd_bin(const binary_request& cmd) {
             return true;
         };
         if( cmd.exptime() != binary_request::EXPTIME_NONE ) {
-            c = [this,&cmd,&r](const cybozu::hash_key& k) -> std::unique_ptr<object> {
-                auto t = std::unique_ptr<object>(
-                    new object(cmd.initial(), cmd.exptime()) );
+            c = [this,&cmd,&r](const cybozu::hash_key& k) -> object {
+                object o(cmd.initial(), cmd.exptime());
                 if( ! cmd.quiet() )
-                    r.incdec( cmd.initial(), t->cas_unique() );
+                    r.incdec( cmd.initial(), o.cas_unique() );
                 if( ! m_slaves.empty() )
-                    repl_object(m_slaves, k, *t);
-                return std::move(t);
+                    repl_object(m_slaves, k, o);
+                return std::move(o);
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) )
@@ -490,18 +487,16 @@ inline void worker::exec_cmd_txt(const mc::text_request& cmd) {
             return true;
         };
         if( cmd.command() != text_command::REPLACE ) {
-            c = [this,&cmd,&r](const cybozu::hash_key& k)
-                -> std::unique_ptr<object> {
+            c = [this,&cmd,&r](const cybozu::hash_key& k) -> object {
                 const char* p2;
                 std::size_t len2;
                 std::tie(p2, len2) = cmd.data();
-                auto t = std::unique_ptr<object>(
-                    new object(p2, len2, cmd.flags(), cmd.exptime()) );
+                object o(p2, len2, cmd.flags(), cmd.exptime());
                 if( ! cmd.no_reply() )
                     r.stored();
                 if( ! m_slaves.empty() )
-                    repl_object(m_slaves, k, *t);
-                return std::move(t);
+                    repl_object(m_slaves, k, o);
+                return std::move(o);
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) && ! cmd.no_reply() )

--- a/test/hash_map.cpp
+++ b/test/hash_map.cpp
@@ -20,8 +20,8 @@ bool reader(const cybozu::hash_key&, std::string& s) {
     return true;
 }
 
-std::unique_ptr<std::string> creator(const cybozu::hash_key& k) {
-    return std::unique_ptr<std::string>( new std::string("hoge") );
+std::string creator(const cybozu::hash_key& k) {
+    return std::string("hoge");
 }
 
 const char key1[] = "abc";
@@ -49,5 +49,7 @@ int main(int argc, char** argv) {
                 std::cout << "collecting " << s << std::endl;
                 return s.size() == 4; });
     }
+    std::cerr << m.apply(hkey1, reader, nullptr) << std::endl;
+    std::cerr << m.apply(hkey2, reader, nullptr) << std::endl;
     return 0;
 }


### PR DESCRIPTION
`cybozu::hash_map` now uses a forward list of pointers instead of `std::vector`.

This also fixes a memory corruption bug along with server-side locking.
