### PR TITLE
Implement "secure_erase" option.

### DIFF
--- a/cybozu/dynbuf.hpp
+++ b/cybozu/dynbuf.hpp
@@ -166,14 +166,17 @@ private:
         if( additional == 0 )
             return;
         const std::size_t new_capacity = m_capacity + additional;
-        char * const new_p = _malloc(new_capacity);
-        if( m_p ) {
-            std::memcpy(new_p, m_p, m_used);
-            if( m_erase )
+        if( m_erase ) {
+            char * const new_p = _malloc(new_capacity);
+            if( m_p ) {
+                std::memcpy(new_p, m_p, m_used);
                 clear_memory(m_p, m_used);
-            _free(m_p);
+                _free(m_p);
+            }
+            m_p = new_p;
+        } else {
+            m_p = _realloc(m_p, new_capacity);
         }
-        m_p = new_p;
         m_capacity = new_capacity;
     }
 

--- a/cybozu/signal.cpp
+++ b/cybozu/signal.cpp
@@ -9,11 +9,13 @@ namespace {
 
 const char ABORT_MESSAGE[] = "got SIGABRT.\n";
 
+#pragma GCC diagnostic ignored "-Wunused-result"
 void handle_abort [[noreturn]] (int) {
-    ::write(STDERR_FILENO, ABORT_MESSAGE, sizeof(ABORT_MESSAGE) - 1);
+    (void)::write(STDERR_FILENO, ABORT_MESSAGE, sizeof(ABORT_MESSAGE) - 1);
     cybozu::dump_stack();
     std::abort();
 }
+#pragma GCC diagnostic pop
 
 } // anonymous namespace
 

--- a/cybozu/signal.cpp
+++ b/cybozu/signal.cpp
@@ -11,7 +11,7 @@ const char ABORT_MESSAGE[] = "got SIGABRT.\n";
 
 #pragma GCC diagnostic ignored "-Wunused-result"
 void handle_abort [[noreturn]] (int) {
-    (void)::write(STDERR_FILENO, ABORT_MESSAGE, sizeof(ABORT_MESSAGE) - 1);
+    ::write(STDERR_FILENO, ABORT_MESSAGE, sizeof(ABORT_MESSAGE) - 1);
     cybozu::dump_stack();
     std::abort();
 }

--- a/cybozu/util.cpp
+++ b/cybozu/util.cpp
@@ -25,15 +25,24 @@ demangler::demangler(const char* name) {
     }
 }
 
+#pragma GCC diagnostic ignored "-Wunused-result"
 void dump_stack() noexcept {
     char buf[32];
     std::time_t t = std::time(nullptr);
     std::size_t len = std::strlen(ctime_r(&t, buf));
-    write(STDERR_FILENO, buf, len);
+    ::write(STDERR_FILENO, buf, len);
 
     void* bt[100];
     int n = backtrace(bt, 100);
     backtrace_symbols_fd(bt, n, STDERR_FILENO);
 }
+#pragma GCC diagnostic pop
+
+void clear_memory_(void* s, std::size_t n) {
+    volatile unsigned char *p = (unsigned char*)s;
+    while( n-- ) *p++ = 0;
+}
+
+void (* const volatile clear_memory)(void* s, std::size_t n) = clear_memory_;
 
 } // namespace cybozu

--- a/cybozu/util.hpp
+++ b/cybozu/util.hpp
@@ -4,6 +4,7 @@
 #ifndef CYBOZU_UTIL_HPP
 #define CYBOZU_UTIL_HPP
 
+#include <cstddef>
 #include <cstring>
 #include <endian.h>
 #include <string>
@@ -94,6 +95,14 @@ inline void hton(UInt d, char* p) noexcept {
         return;
     }
 }
+
+
+// Clear memory securely just like memset_s in C11.
+// @s  A pointer to a memory region.
+// @n  The length of the memory region in bytes.
+extern void (* const volatile clear_memory)(void* s, std::size_t n);
+
+
 
 } // namespace cybozu
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -22,6 +22,7 @@ const char BUCKETS[] = "buckets";
 const char MAX_DATA_SIZE[] = "max_data_size";
 const char HEAP_DATA_LIMIT[] = "heap_data_limit";
 const char MEMORY_LIMIT[] = "memory_limit";
+const char SECURE_ERASE[] = "secure_erase";
 const char WORKERS[] = "workers";
 const char GC_INTERVAL[] = "gc_interval";
 const char COUNTER_ENABLE[] = "counter.enable";
@@ -186,6 +187,10 @@ void config::load(const std::string& path) {
         if( t.empty() )
             throw bad_config("memory_limit must not be empty");
         m_memory_limit = parse_unit(t, MEMORY_LIMIT);
+    }
+
+    if( cp.exists(SECURE_ERASE) ) {
+        m_secure_erase = cp.get_as_bool(SECURE_ERASE);
     }
 
     if( cp.exists(WORKERS) ) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -104,6 +104,9 @@ public:
     std::size_t memory_limit() const noexcept {
         return m_memory_limit;
     }
+    bool secure_erase() const noexcept {
+        return m_secure_erase;
+    }
     unsigned int workers() const noexcept {
         return m_workers;
     }
@@ -134,6 +137,7 @@ private:
     std::size_t m_max_data_size = DEFAULT_MAX_DATA_SIZE;
     std::size_t m_heap_data_limit = DEFAULT_HEAP_DATA_LIMIT;
     std::size_t m_memory_limit = DEFAULT_MEMORY_LIMIT;
+    bool m_secure_erase = false;
     unsigned int m_workers = DEFAULT_WORKER_THREADS;
     unsigned int m_gc_interval = DEFAULT_GC_INTERVAL;
     counter_config m_counter_config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,18 +51,27 @@ void seed_siphash() {
 
 bool load_config(const std::vector<std::string>& args) {
     auto it = std::find(args.begin(), args.end(), "-f");
+    using yrmcds::g_config;
     if( it != args.end() ) {
         ++it;
         if( it == args.end() ) {
             std::cerr << "missing filename after -f" << std::endl;
             return false;
         }
-        yrmcds::g_config.load(*it);
+        g_config.load(*it);
     } else {
         std::string config_path = EXPAND_AND_QUOTE(DEFAULT_CONFIG);
         struct stat st;
         if( cybozu::get_stat(config_path, st) )
-            yrmcds::g_config.load( config_path );
+            g_config.load( config_path );
+    }
+    if( g_config.secure_erase() &&
+        (g_config.max_data_size() > g_config.heap_data_limit()) ) {
+        std::cerr << "WARNING: " << std::endl
+                  << "   \"secure_erase\" is enabled but your data may be written out to disk."
+                  << std::endl
+                  << "   Consider setting \"max_data_size\" equal to \"heap_data_limit\"."
+                  << std::endl;
     }
     return true;
 }

--- a/src/memcache/object.cpp
+++ b/src/memcache/object.cpp
@@ -34,9 +34,9 @@ file_flusher::~file_flusher() {
 }
 
 object::object(const char* p, std::size_t len,
-               std::uint32_t flags_, std::time_t exptime):
-    m_length(len), m_data(0), m_file(nullptr),
-    m_flags(flags_), m_exptime(exptime) {
+               std::uint32_t flags_, std::time_t exptime)
+    : m_length(len), m_data(0, g_config.secure_erase()), m_file(nullptr),
+      m_flags(flags_), m_exptime(exptime) {
     if( len > g_config.heap_data_limit() ) {
         m_file = std::unique_ptr<tempfile>(new tempfile);
         m_file->write(p, len);
@@ -47,8 +47,9 @@ object::object(const char* p, std::size_t len,
     g_stats.total_objects.fetch_add(1, std::memory_order_relaxed);
 }
 
-object::object(std::uint64_t initial, std::time_t exptime):
-    m_length(0), m_data(24), m_file(nullptr), m_flags(0), m_exptime(exptime) {
+object::object(std::uint64_t initial, std::time_t exptime)
+    : m_length(0), m_data(24, g_config.secure_erase()),
+      m_file(nullptr), m_flags(0), m_exptime(exptime) {
     char s_value[24]; // uint64 can be as large as 20 byte decimal string.
     m_length = ::snprintf(s_value, sizeof(s_value),
                           "%llu", (unsigned long long)initial);

--- a/test/clear_memory.cpp
+++ b/test/clear_memory.cpp
@@ -1,0 +1,10 @@
+#include <cybozu/util.hpp>
+#include <cybozu/test.hpp>
+
+AUTOTEST(clear_memory) {
+    char hoge[] = "abcdef";
+    cybozu::clear_memory(hoge, sizeof(hoge));
+    for( auto i = sizeof(hoge); i > 0; --i ) {
+        cybozu_assert(hoge[i] == '\0');
+    }
+}

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -13,6 +13,7 @@ AUTOTEST(config) {
     cybozu_assert(g_config.user() == "nobody");
     cybozu_assert(g_config.group() == "nogroup");
     cybozu_assert(g_config.memory_limit() == (1024 << 20));
+    cybozu_assert(g_config.secure_erase() == true);
     cybozu_assert(g_config.threshold() == cybozu::severity::warning);
     cybozu_assert(g_config.max_data_size() == (5 << 20));
     cybozu_assert(g_config.heap_data_limit() == (16 << 10));

--- a/test/test.conf
+++ b/test/test.conf
@@ -13,6 +13,7 @@ buckets		= 1000000
 max_data_size	= 5M
 heap_data_limit	= 16K
 memory_limit	= 1024M
+secure_erase	= true
 workers		= 10
 gc_interval	= 20
 


### PR DESCRIPTION
This p-r adds a new configuration option `secure_erase`.

If the option is set, the contents on memory will be cleared securely before freeing.

Note that when `max_data_size` > `heap_data_limit`, objects data may be written
out to a persistent storage.  In such case, yrmcdsd emits an warning.

Closes #41 when merged.