### PR TITLE
fix: load out of hoge

### DIFF
--- a/test/clear_memory.cpp
+++ b/test/clear_memory.cpp
@@ -4,7 +4,7 @@
 AUTOTEST(clear_memory) {
     char hoge[] = "abcdef";
     cybozu::clear_memory(hoge, sizeof(hoge));
-    for( auto i = sizeof(hoge); i > 0; --i ) {
-        cybozu_assert(hoge[i] == '\0');
+    for( char c : hoge ) {
+        cybozu_assert(c == '\0');
     }
 }


### PR DESCRIPTION
Is it intended code that the memory out of hoge is accessed?