### PR TITLE
Implement lock_memory config option

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,6 +49,8 @@ These options are to configure memcache protocol:
     Objects larger than this will be stored in temporary files.
 * `secure_erase` (Default: false)  
     If `true`, object memory will be cleared as soon as the object is removed.
+* `lock_memory` (Default: false)  
+    If `true`, prevent memory from being swapped using `mlockall`.
 * `memory_limit` (Default: 1024M)  
     The amount of memory allowed for yrmcdsd.
 * `workers` (Default: 8)  
@@ -146,8 +148,21 @@ Consider setting `max_data_size` equal to `heap_data_limit` when you
 enable this option to avoid writing confidential data into persistent
 storage.
 
+Locking memory
+--------------
+
+If `lock_memory` configuration option is enabled, `yrmcdsd` will lock
+memory with `mlockall` to prevent them from being swapped.
+
+**Use of this option may cause troubles**; locking enough memory for
+yrmcds will require the process having `CAP_IPC_LOCK` capability or
+sufficiently large `RLIMIT_MEMLOCK` resource limit.
+
+See [man page][mlockall] for details.
+
 
 [keepalived]: http://www.keepalived.org/
 [pacemaker]: http://clusterlabs.org/wiki/Main_Page
 [upstart]: http://upstart.ubuntu.com/
 [systemd]: http://www.freedesktop.org/wiki/Software/systemd/
+[mlockall]: http://manpages.ubuntu.com/manpages/trusty/en/man2/mlockall.2.html

--- a/etc/upstart
+++ b/etc/upstart
@@ -9,6 +9,7 @@ respawn
 
 umask 077
 limit nofile 100000 100000
+limit memlock unlimited unlimited
 chdir /tmp
 
 pre-start script

--- a/etc/yrmcds.conf
+++ b/etc/yrmcds.conf
@@ -46,6 +46,9 @@ heap_data_limit = 256K
 # you enable this option.
 secure_erase = false
 
+# Prevent memory from being swapped by using mlockall(2).
+lock_memory = false
+
 # The amount of memory allowed for the entire yrmcds.
 # This is by no means a hard limit; rather, this is just a hint for
 # the garbage collection.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,6 +23,7 @@ const char MAX_DATA_SIZE[] = "max_data_size";
 const char HEAP_DATA_LIMIT[] = "heap_data_limit";
 const char MEMORY_LIMIT[] = "memory_limit";
 const char SECURE_ERASE[] = "secure_erase";
+const char LOCK_MEMORY[] = "lock_memory";
 const char WORKERS[] = "workers";
 const char GC_INTERVAL[] = "gc_interval";
 const char COUNTER_ENABLE[] = "counter.enable";
@@ -191,6 +192,10 @@ void config::load(const std::string& path) {
 
     if( cp.exists(SECURE_ERASE) ) {
         m_secure_erase = cp.get_as_bool(SECURE_ERASE);
+    }
+
+    if( cp.exists(LOCK_MEMORY) ) {
+        m_lock_memory = cp.get_as_bool(LOCK_MEMORY);
     }
 
     if( cp.exists(WORKERS) ) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -107,6 +107,9 @@ public:
     bool secure_erase() const noexcept {
         return m_secure_erase;
     }
+    bool lock_memory() const noexcept {
+        return m_lock_memory;
+    }
     unsigned int workers() const noexcept {
         return m_workers;
     }
@@ -138,6 +141,7 @@ private:
     std::size_t m_heap_data_limit = DEFAULT_HEAP_DATA_LIMIT;
     std::size_t m_memory_limit = DEFAULT_MEMORY_LIMIT;
     bool m_secure_erase = false;
+    bool m_lock_memory = false;
     unsigned int m_workers = DEFAULT_WORKER_THREADS;
     unsigned int m_gc_interval = DEFAULT_GC_INTERVAL;
     counter_config m_counter_config;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,11 +10,13 @@
 #include <cybozu/util.hpp>
 
 #include <algorithm>
+#include <cerrno>
 #include <grp.h>
 #include <iostream>
 #include <pwd.h>
 #include <random>
 #include <string>
+#include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/types.h>
 #include <typeinfo>
@@ -100,6 +102,11 @@ int main(int argc, char** argv) {
     try {
         if( ! load_config(args) )
             return 1;
+
+        if( yrmcds::g_config.lock_memory() ) {
+            if( ::mlockall( MCL_CURRENT | MCL_FUTURE ) == -1 )
+                cybozu::throw_unix_error(errno, "mlockall");
+        }
 
         // first, set group id (as root)
         const std::string& g = yrmcds::g_config.group();

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -14,6 +14,7 @@ AUTOTEST(config) {
     cybozu_assert(g_config.group() == "nogroup");
     cybozu_assert(g_config.memory_limit() == (1024 << 20));
     cybozu_assert(g_config.secure_erase() == true);
+    cybozu_assert(g_config.lock_memory() == true);
     cybozu_assert(g_config.threshold() == cybozu::severity::warning);
     cybozu_assert(g_config.max_data_size() == (5 << 20));
     cybozu_assert(g_config.heap_data_limit() == (16 << 10));

--- a/test/test.conf
+++ b/test/test.conf
@@ -14,6 +14,7 @@ max_data_size	= 5M
 heap_data_limit	= 16K
 memory_limit	= 1024M
 secure_erase	= true
+lock_memory	= true
 workers		= 10
 gc_interval	= 20
 


### PR DESCRIPTION
This PR implements a new config option "lock_memory".

If true, yrmcds locks memory by using `mlockall`.

Closes #44 when merged.