### PR TITLE
Add "bind_ip" config option

### DIFF
--- a/cybozu/util.cpp
+++ b/cybozu/util.cpp
@@ -50,7 +50,7 @@ void dump_stack() noexcept {
 
 std::vector<std::string> tokenize(const std::string& s, char c) {
     auto end = s.cend();
-    auto start = end;
+    auto start = end;  // initially, token start position is not set.
 
     std::vector<std::string> v;
     for( auto it = s.cbegin(); it != end; ++it ) {

--- a/cybozu/util.cpp
+++ b/cybozu/util.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <execinfo.h>
+#include <iostream>
 #include <sstream>
 #include <string.h>
 #include <stdexcept>
@@ -46,6 +47,27 @@ void dump_stack() noexcept {
     backtrace_symbols_fd(bt, n, STDERR_FILENO);
 }
 #pragma GCC diagnostic pop
+
+std::vector<std::string> tokenize(const std::string& s, char c) {
+    auto end = s.cend();
+    auto start = end;
+
+    std::vector<std::string> v;
+    for( auto it = s.cbegin(); it != end; ++it ) {
+        if( *it != c ) {
+            if( start == end )
+                start = it;
+            continue;
+        }
+        if( start != end ) {
+            v.emplace_back(start, it);
+            start = end;
+        }
+    }
+    if( start != end )
+        v.emplace_back(start, end);
+    return std::move(v);
+}
 
 void (* const volatile clear_memory)(void* s, std::size_t n) = clear_memory_;
 

--- a/cybozu/util.cpp
+++ b/cybozu/util.cpp
@@ -66,7 +66,7 @@ std::vector<std::string> tokenize(const std::string& s, char c) {
     }
     if( start != end )
         v.emplace_back(start, end);
-    return std::move(v);
+    return v;
 }
 
 void (* const volatile clear_memory)(void* s, std::size_t n) = clear_memory_;

--- a/cybozu/util.hpp
+++ b/cybozu/util.hpp
@@ -9,6 +9,7 @@
 #include <endian.h>
 #include <string>
 #include <system_error>
+#include <vector>
 
 namespace cybozu {
 
@@ -95,6 +96,12 @@ inline void hton(UInt d, char* p) noexcept {
         return;
     }
 }
+
+
+// Tokenize a string by given delimiter.
+// @s  String to be tokenized.
+// @c  Delimiter.
+std::vector<std::string> tokenize(const std::string& s, char c);
 
 
 // Clear memory securely just like memset_s in C11.

--- a/cybozu/util.hpp
+++ b/cybozu/util.hpp
@@ -101,6 +101,11 @@ inline void hton(UInt d, char* p) noexcept {
 // Tokenize a string by given delimiter.
 // @s  String to be tokenized.
 // @c  Delimiter.
+//
+// This function splits the given string using `c` as a delimiter.
+// The result will not contain the delimiter nor empty strings.
+//
+// @return  A vector of string tokens.
 std::vector<std::string> tokenize(const std::string& s, char c);
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,6 +33,9 @@ These options are to configure memcache protocol:
     memcache protocol port number.
 * `repl_port` (Default: 11213)  
     The replication protocol port number.
+* `bind_ip` (Default: none)  
+    Space delimited IP addresses to listen on.  
+    Default is to listen on all addresses.
 * `max_connections` (Default: 0)  
     Maximum number of client connections.  0 means unlimited.
 * `temp_dir` (Default: /var/tmp)  

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,8 @@ These options are to configure memcache protocol:
     The replication protocol port number.
 * `bind_ip` (Default: none)  
     Space delimited IP addresses to listen on.  
-    Default is to listen on all addresses.
+    Default is to listen on all addresses.  
+    Note that `virtual_ip` will be bound in addition to `bind_ip`.
 * `max_connections` (Default: 0)  
     Maximum number of client connections.  0 means unlimited.
 * `temp_dir` (Default: /var/tmp)  

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -12,6 +12,7 @@ namespace {
 const char VIRTUAL_IP[] = "virtual_ip";
 const char PORT[] = "port";
 const char REPL_PORT[] = "repl_port";
+const char BIND_IP[] = "bind_ip";
 const char MAX_CONNECTIONS[] = "max_connections";
 const char TEMP_DIR[] = "temp_dir";
 const char USER[] = "user";
@@ -122,6 +123,12 @@ void config::load(const std::string& path) {
         if( n < 1 || n > 65535 )
             throw bad_config("Bad repl port: " + cp.get(REPL_PORT));
         m_repl_port = static_cast<std::uint16_t>(n);
+    }
+
+    if( cp.exists(BIND_IP) ) {
+        for( auto& s: cybozu::tokenize(cp.get(BIND_IP), ' ') ) {
+            m_bind_ip.emplace_back(s);
+        }
     }
 
     if( cp.exists(MAX_CONNECTIONS) ) {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -12,6 +12,7 @@
 
 #include <stdexcept>
 #include <cstdint>
+#include <vector>
 
 namespace yrmcds {
 
@@ -73,6 +74,9 @@ public:
     }
     std::uint16_t repl_port() const noexcept {
         return m_repl_port;
+    }
+    const std::vector<cybozu::ip_address>& bind_ip() const noexcept {
+        return m_bind_ip;
     }
     unsigned int max_connections() const noexcept {
         return m_max_connections;
@@ -136,6 +140,7 @@ private:
     cybozu::ip_address m_vip;
     std::uint16_t m_port = DEFAULT_MEMCACHE_PORT;
     std::uint16_t m_repl_port = DEFAULT_REPL_PORT;
+    std::vector<cybozu::ip_address> m_bind_ip;
     unsigned int m_max_connections = 0;
     std::string m_tempdir;
     std::string m_user;

--- a/src/memcache/handler.cpp
+++ b/src/memcache/handler.cpp
@@ -68,8 +68,20 @@ void handler::on_start() {
         [this](int s, const cybozu::ip_address&) {
         return make_memcache_socket(s);
     };
-    m_reactor.add_resource(make_server_socket(NULL, g_config.port(), w),
-                           cybozu::reactor::EVENT_IN);
+    if( g_config.bind_ip().empty() ) {
+        m_reactor.add_resource(
+            make_server_socket(nullptr, g_config.port(), w),
+            cybozu::reactor::EVENT_IN);
+    } else {
+        m_reactor.add_resource(
+            make_server_socket(g_config.vip(), g_config.port(), w, true),
+            cybozu::reactor::EVENT_IN);
+        for( auto& s: g_config.bind_ip() ) {
+            m_reactor.add_resource(
+                make_server_socket(s, g_config.port(), w),
+                cybozu::reactor::EVENT_IN);
+        }
+    }
 }
 
 void handler::on_master_start() {
@@ -78,8 +90,20 @@ void handler::on_master_start() {
         [this](int s, const cybozu::ip_address&) {
         return make_repl_socket(s);
     };
-    m_reactor.add_resource(make_server_socket(NULL, g_config.repl_port(), w),
-                           cybozu::reactor::EVENT_IN);
+    if( g_config.bind_ip().empty() ) {
+        m_reactor.add_resource(
+            make_server_socket(nullptr, g_config.repl_port(), w),
+            cybozu::reactor::EVENT_IN);
+    } else {
+        m_reactor.add_resource(
+            make_server_socket(g_config.vip(), g_config.repl_port(), w, true),
+            cybozu::reactor::EVENT_IN);
+        for( auto& s: g_config.bind_ip() ) {
+            m_reactor.add_resource(
+                make_server_socket(s, g_config.repl_port(), w),
+                cybozu::reactor::EVENT_IN);
+        }
+    }
 }
 
 void handler::on_master_interval() {

--- a/src/memcache/handler.cpp
+++ b/src/memcache/handler.cpp
@@ -227,6 +227,8 @@ std::unique_ptr<cybozu::tcp_socket> handler::make_repl_socket(int s) {
         std::unique_ptr<sync_request>(
             new sync_request([this,pt]{ m_new_slaves.push_back(pt); })
             ));
+    // explicit move is required for C++11 (and gcc-4.8.x).
+    // C++14 (and gcc-5.x) can implicitly move t.
     return std::move(t);
 }
 

--- a/src/memcache/sockets.cpp
+++ b/src/memcache/sockets.cpp
@@ -298,7 +298,7 @@ void memcache_socket::cmd_bin(const memcache::binary_request& cmd) {
                     r.set( o.cas_unique() );
                 if( ! m_slaves.empty() )
                     repl_object(m_slaves, k, o);
-                return std::move(o);
+                return o;
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) ) {
@@ -454,7 +454,7 @@ void memcache_socket::cmd_bin(const memcache::binary_request& cmd) {
                     r.incdec( cmd.initial(), o.cas_unique() );
                 if( ! m_slaves.empty() )
                     repl_object(m_slaves, k, o);
-                return std::move(o);
+                return o;
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) )
@@ -492,7 +492,7 @@ void memcache_socket::cmd_bin(const memcache::binary_request& cmd) {
                     r.incdec( cmd.initial(), o.cas_unique() );
                 if( ! m_slaves.empty() )
                     repl_object(m_slaves, k, o);
-                return std::move(o);
+                return o;
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) )
@@ -668,7 +668,7 @@ void memcache_socket::cmd_text(const memcache::text_request& cmd) {
                     r.stored();
                 if( ! m_slaves.empty() )
                     repl_object(m_slaves, k, o);
-                return std::move(o);
+                return o;
             };
         }
         if( ! m_hash.apply(cybozu::hash_key(p, len), h, c) && ! cmd.no_reply() )

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -9,6 +9,7 @@ AUTOTEST(config) {
     g_config.load(TEST_CONF);
     cybozu_assert(g_config.port() == 1121);
     cybozu_assert(g_config.repl_port() == 1122);
+    cybozu_assert(g_config.bind_ip().size() == 2);
     cybozu_assert(g_config.max_connections() == 10000);
     cybozu_assert(g_config.user() == "nobody");
     cybozu_assert(g_config.group() == "nogroup");

--- a/test/counter_client.hpp
+++ b/test/counter_client.hpp
@@ -112,7 +112,7 @@ public:
                           std::string(p + 4 + name_len, value_len) });
             p += 4 + name_len + value_len;
         }
-        return std::move(s);
+        return s;
     }
 
 private:

--- a/test/test.conf
+++ b/test/test.conf
@@ -3,6 +3,7 @@
 virtual_ip	= 127.0.0.1
 port		= 1121
 repl_port	= 1122
+bind_ip		= 10.1.2.3  127.0.1.2
 max_connections	= 10000
 temp_dir	= "/var/tmp"
 user		= nobody

--- a/test/tokenize.cpp
+++ b/test/tokenize.cpp
@@ -1,0 +1,17 @@
+#include <cybozu/test.hpp>
+#include <cybozu/util.hpp>
+
+AUTOTEST(tokenize) {
+    cybozu_assert(cybozu::tokenize("", ' ').empty());
+    cybozu_assert(cybozu::tokenize(" ", ' ').empty());
+    cybozu_assert(cybozu::tokenize(" a", ' ') ==
+                  std::vector<std::string>{"a"});
+    cybozu_assert(cybozu::tokenize("a ", ' ') ==
+                  std::vector<std::string>{"a"});
+    cybozu_assert(cybozu::tokenize(" abc  def ", ' ') ==
+                  std::vector<std::string>{"abc", "def"});
+    cybozu_assert(cybozu::tokenize(" abc  def g", ' ') ==
+                  std::vector<std::string>{"abc", "def", "g"});
+    cybozu_assert(cybozu::tokenize("0123", ' ') ==
+                  std::vector<std::string>{"0123"});
+}


### PR DESCRIPTION
This PR adds a new config option "bind_ip".

bind_ip is a list of IP addresses to which yrmcds bind its sockets.
If bind_ip is empty, yrmcds continues to listen on all interfaces.

Close #63.