### PR TITLE
Support gcc7

### DIFF
--- a/cybozu/hash_map.hpp
+++ b/cybozu/hash_map.hpp
@@ -14,6 +14,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include <functional>
 
 namespace cybozu {
 


### PR DESCRIPTION
gcc 7 put the following message, then I add -faligned-new option, but I don't know that it is best way.
```
src/counter/handler.cpp: In member function 'std::unique_ptr<cybozu::tcp_socket> yrmcds::counter::handler::make_counter_socket(int)':
src/counter/handler.cpp:72:47: warning: 'new' of type 'yrmcds::counter::counter_socket' with extended alignment 64 [-Waligned-new=]
         new counter_socket(s, m_finder, m_hash) );
```