### PR TITLE
Increase hardcoded listen backlog value

### DIFF
--- a/cybozu/tcp.cpp
+++ b/cybozu/tcp.cpp
@@ -445,7 +445,7 @@ setup_server_socket(const char* bind_addr, std::uint16_t port, bool freebind) {
     }
     freeaddrinfo(res);
 
-    if( listen(s, 128) == -1 ) {
+    if( listen(s, 4096) == -1 ) {
         ::close(s);
         throw_unix_error(errno, "listen");
     }


### PR DESCRIPTION
Currently, the listen backlog is hardcoded to 128 regardless of system settings. (https://github.com/cybozu/yrmcds/blob/master/cybozu/tcp.cpp#L448)