### PR TITLE
Make the compiler configurable via environment variables

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,12 @@ jobs:
         run: |
           $CC --version
           $CXX --version
-          make -j 4 CC=${{ matrix.compiler[0] }} CXX=${{ matrix.compiler[1] }} OPTFLAGS="-O2 -fPIE"
+          make -j 4 CC=$CC CXX=$CXX OPTFLAGS="-O2 -fPIE"
           ./yrmcdsd &
           sleep 1
+        env:
+          CC: ${{ matrix.compiler[0] }}
+          CXX: ${{ matrix.compiler[1] }}
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,14 +23,9 @@ jobs:
         run: |
           $CC --version
           $CXX --version
-          make -j 4
+          make -j 4 CC=${{ matrix.compiler[0] }} CXX=${{ matrix.compiler[1] }} OPTFLAGS="-O2 -fPIE"
           ./yrmcdsd &
           sleep 1
-        env:
-          CC: ${{ matrix.compiler[0] }}
-          CFLAGS: -fPIE
-          CXX: ${{ matrix.compiler[1] }}
-          CXXFLAGS: -fPIE
 
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ ifeq ($(CACHELINE_SIZE), 0)
 	CACHELINE_SIZE = 32
 endif
 
-CC = gcc
-CXX = g++
+CC ?= gcc
+CXX ?= g++
 CPPFLAGS = -I. -DCACHELINE_SIZE=$(CACHELINE_SIZE) $(TCMALLOC_FLAGS)
 CPPFLAGS += -DDEFAULT_CONFIG=$(DEFAULT_CONFIG)
 OPTFLAGS = -O2 #-flto
 DEBUGFLAGS = -gdwarf-3 #-fsanitize=address
 WARNFLAGS = -Wall -Wnon-virtual-dtor -Woverloaded-virtual
 CPUFLAGS = #-march=core2 -mtune=corei7
-CXXFLAGS = -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS)
+CXXFLAGS := -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS) $(CXXFLAGS)
 LDFLAGS = -L. $(shell getconf LFS_LDFLAGS)
 LDLIBS = $(shell getconf LFS_LIBS) -lyrmcds $(LIBTCMALLOC) -latomic -lpthread
 CLDOC := LD_LIBRARY_PATH=$(shell llvm-config --libdir 2>/dev/null) cldoc

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ ifeq ($(CACHELINE_SIZE), 0)
 	CACHELINE_SIZE = 32
 endif
 
-CC ?= gcc
-CXX ?= g++
+CC = gcc
+CXX = g++
 CPPFLAGS = -I. -DCACHELINE_SIZE=$(CACHELINE_SIZE) $(TCMALLOC_FLAGS)
 CPPFLAGS += -DDEFAULT_CONFIG=$(DEFAULT_CONFIG)
 OPTFLAGS = -O2 #-flto
 DEBUGFLAGS = -gdwarf-3 #-fsanitize=address
 WARNFLAGS = -Wall -Wnon-virtual-dtor -Woverloaded-virtual
 CPUFLAGS = #-march=core2 -mtune=corei7
-CXXFLAGS := -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS) $(CXXFLAGS)
+CXXFLAGS = -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS)
 LDFLAGS = -L. $(shell getconf LFS_LDFLAGS)
 LDLIBS = $(shell getconf LFS_LIBS) -lyrmcds $(LIBTCMALLOC) -latomic -lpthread
 CLDOC := LD_LIBRARY_PATH=$(shell llvm-config --libdir 2>/dev/null) cldoc


### PR DESCRIPTION
This pull request aims to make the compiler configurable.
With the current `Makefile` configuration, `gcc` and `g++` are always used as the compiler, even if clang is specified as the compiler in CI.
