### PR TITLE
Increase MAX_BUFCNT to 65536

### DIFF
--- a/cybozu/tcp.cpp
+++ b/cybozu/tcp.cpp
@@ -27,7 +27,7 @@
 
 namespace {
 
-const unsigned int MAX_BUFCNT = 100;
+const unsigned int MAX_BUFCNT = 65536;
 const int KEEPALIVE_IDLE = 300;   // 5 min before keep alive probe
 const int KEEPALIVE_INTERVAL = 5; // 5 seconds between keep alive probes
 


### PR DESCRIPTION
We are running yrmcds with the memory_limit = 32G configuration. When we add a slave with this configuration, the following message is displayed on the primary node and "Slave start" and "Slave end" are repeatedly displayed on the slave node.

```
WARN Replication buffer is full. Please enlarge "repl_buffer_size" to avoid the hang up of yrmcds.
```

We followed this message and specified repl_buffer_size = 400. However, the following error prevented our configuration.

```
Exception [std::logic_error] tcp_socket: Too many buffers
```