### PR TITLE
Add logs when the server terminates

### DIFF
--- a/src/memcache/sockets.cpp
+++ b/src/memcache/sockets.cpp
@@ -996,12 +996,14 @@ bool repl_client_socket::on_readable() {
             if( errno == EINTR )
                 continue;
             if( errno == ECONNRESET ) {
+                cybozu::logger::warning() << "The connection to master has been reset.";
                 m_reactor->quit();
                 return invalidate();
             }
             cybozu::throw_unix_error(errno, "recv");
         }
         if( n == 0 ) {
+            cybozu::logger::info() << "The connection to master has been closed.";
             m_reactor->quit();
             return invalidate();
         }

--- a/src/memcache/sockets.hpp
+++ b/src/memcache/sockets.hpp
@@ -140,10 +140,12 @@ private:
 
     virtual bool on_readable() override final;
     virtual bool on_hangup() override final {
+        cybozu::logger::warning() << "The connection to master has hung up.";
         m_reactor->quit();
         return invalidate();
     }
     virtual bool on_error() override final {
+        cybozu::logger::warning() << "An error occurred on the connection to master.";
         m_reactor->quit();
         return invalidate();
     }


### PR DESCRIPTION
There is too little logging when Slave exits. This makes it difficult to investigate Slave problems when they occur. Therefore, we will add logging.