### PR TITLE
Fix slave death during huge initial replication

### DIFF
--- a/src/memcache/handler.cpp
+++ b/src/memcache/handler.cpp
@@ -227,6 +227,15 @@ std::unique_ptr<cybozu::tcp_socket> handler::make_repl_socket(int s) {
         std::unique_ptr<sync_request>(
             new sync_request([this,pt]{ m_new_slaves.push_back(pt); })
             ));
+
+    std::string addr = "unknown address";
+    try {
+        addr = cybozu::get_peer_ip_address(s).str();
+    } catch (...) {
+        // ignore errors
+    }
+    cybozu::logger::info() << "A new slave (" << addr << ") has joined.";
+
     // explicit move is required for C++11 (and gcc-4.8.x).
     // C++14 (and gcc-5.x) can implicitly move t.
     return std::move(t);


### PR DESCRIPTION
`repl_client_socket::on_readable` is executed in the same thread as the function that sends heartbeats. If the function takes a very long time, no heartbeats will be sent, and the process will be judged dead by the master. 

This situation actually occurs when the transmission speed of the master is faster than the processing speed of the slave during huge initial replication.

To fix this problem, set an upper limit on the number of loops in `repl_client_socket::on_readable`.