### PR TITLE
Purge python2 dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ CPUFLAGS = #-march=core2 -mtune=corei7
 CXXFLAGS = -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS)
 LDFLAGS = -L. $(shell getconf LFS_LDFLAGS)
 LDLIBS = $(shell getconf LFS_LIBS) -lyrmcds $(LIBTCMALLOC) -latomic -lpthread
-CLDOC := LD_LIBRARY_PATH=$(shell llvm-config --libdir 2>/dev/null) cldoc
 
 HEADERS = $(sort $(wildcard src/*.hpp src/*/*.hpp cybozu/*.hpp))
 SOURCES = $(sort $(wildcard src/*.cpp src/*/*.cpp cybozu/*.cpp))
@@ -30,7 +29,7 @@ EXE = yrmcdsd
 TESTS = $(patsubst %.cpp,%,$(sort $(wildcard test/*.cpp)))
 LIB = libyrmcds.a
 LIB_OBJECTS = $(filter-out src/main.o,$(OBJECTS))
-PACKAGES = build-essential libgoogle-perftools-dev python-pip
+PACKAGES = build-essential libgoogle-perftools-dev
 
 TCMALLOC_HEADER := $(shell sh ./detect_tcmalloc.sh $(CXX) $(CPPFLAGS))
 ifeq ($(TCMALLOC_HEADER), gperftools/tcmalloc.h)
@@ -89,19 +88,10 @@ $(TESTS): $(LIB)
 	./$@.exe
 	@echo
 
-html:
-	@clang++ -v 2>/dev/null || (echo "No clang++ in PATH." && false)
-	rm -rf html
-	$(CLDOC) generate $(CPPFLAGS) $(CXXFLAGS) -w -D__STRICT_ANSI__ -- --output html --merge docs $(HEADERS)
-
-serve: html
-	@cd html; python -m SimpleHTTPServer 8888 || true
-
 clean:
 	rm -f src/*.o src/*/*.o cybozu/*.o test/*.o test/*.exe COPYING.hpp $(EXE) $(EXE).map $(LIB)
 
 setup:
 	sudo apt-get install -y --install-recommends $(PACKAGES)
-	sudo pip install cldoc --upgrade
 
-.PHONY: all strip lib tests install install-service html serve clean setup test_env $(TESTS)
+.PHONY: all strip lib tests install install-service clean setup test_env $(TESTS)

--- a/docs/bench.md
+++ b/docs/bench.md
@@ -1,5 +1,3 @@
-#<cldoc:Benchmark Results>
-
 Benchmark results.
 
 Environment

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -1,5 +1,3 @@
-#<cldoc:Counter support>
-
 Counter support
 
 Overview

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,5 +1,3 @@
-#<cldoc:Design Notes>
-
 Design Notes
 ============
 

--- a/docs/diffs.md
+++ b/docs/diffs.md
@@ -1,5 +1,3 @@
-#<cldoc:Differences from memcached>
-
 Differences from memcached.
 
 Differences from memcached 1.4

--- a/docs/future.md
+++ b/docs/future.md
@@ -1,5 +1,3 @@
-#<cldoc:Future Plans>
-
 List of future plans.
 
 Future Plans

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-#<cldoc:index>
-
 Index.
 
 yrmcds documents
@@ -7,10 +5,6 @@ yrmcds documents
 
 yrmcds is an object cache system featuring master-slave replication.
 
-#<cldoc:cybozu>
-
 General utilities.
-
-#<cldoc:yrmcds>
 
 Implementing yrmcds.

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,5 +1,3 @@
-#<cldoc:ExtKeys>
-
 Key dump extesion
 =================
 

--- a/docs/locking.md
+++ b/docs/locking.md
@@ -1,5 +1,3 @@
-#<cldoc:Server-side locking>
-
 Server-side locking support.
 
 Motivation

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,3 @@
-#<cldoc:Usage>
-
 Configuration and execution of `yrmcdsd`.
 
 `yrmcdsd` is the server program of yrmcds.  Its built-in configurations are


### PR DESCRIPTION
yrmcds's Makefile depends on python2 to use cldoc.
I'd like to remove python2 to use yrmcds on Ubuntu 20.04 focal fossa.
cldoc is no longer maintained, and using python3 with it causes errors.
So I remove cldoc and python-pip (i.e. pip2).