### PR TITLE
Early close file descriptors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,26 +8,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        compiler: [[gcc, g++], [clang, clang++]]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        compiler: [{cc: gcc, cxx: g++}, {cc: clang, cxx: clang++}]
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y libgoogle-perftools-dev libunwind-dev
     - name: Build
+      env:
+        CC: ${{ matrix.compiler.cc }}
+        CXX: ${{ matrix.compiler.cxx }}
       run: |
         $CC --version
         $CXX --version
         make -j $(nproc) CC=$CC CXX=$CXX OPTFLAGS="-O2 -fPIE"
         ./yrmcdsd &
         sleep 1
-      env:
-        CC: ${{ matrix.compiler[0] }}
-        CXX: ${{ matrix.compiler[1] }}
     - name: Run tests
       run: |
         make YRMCDS_SERVER=localhost tests

--- a/cybozu/signal.hpp
+++ b/cybozu/signal.hpp
@@ -31,7 +31,7 @@ public:
     signal_reader(const sigset_t *mask, callback_t callback):
         resource( signalfd(-1, mask, SFD_NONBLOCK|SFD_CLOEXEC) ),
         m_callback(callback) {
-        if( m_fd == -1 )
+        if( fileno() == -1 )
             throw_unix_error(errno, "signalfd");
     }
     // Constructor.
@@ -54,8 +54,11 @@ private:
 
     virtual bool on_readable() override final {
         while( true ) {
+            int fd = fileno();
+            if( fd == -1 ) return true;
+
             struct signalfd_siginfo si;
-            ssize_t n = read(m_fd, &si, sizeof(si));
+            ssize_t n = read(fd, &si, sizeof(si));
             if( n == -1 ) {
                 if( errno == EINTR ) continue;
                 if( errno == EAGAIN || errno ==EWOULDBLOCK ) return true;

--- a/cybozu/tcp.hpp
+++ b/cybozu/tcp.hpp
@@ -185,7 +185,7 @@ protected:
     }
 
     virtual void on_invalidate() override {
-        ::shutdown(m_fd, SHUT_RDWR);
+        ::shutdown(fileno(), SHUT_RDWR);
         free_buffers();
         m_cond_write.notify_all();
     }
@@ -223,10 +223,13 @@ private:
         return m_pending.empty() && m_tmpbuf.empty();
     }
     void _flush() {
+        int fd = fileno();
+        if( fd == -1 ) return;
+
         // with TCP_CORK, setting TCP_NODELAY effectively flushes
         // the kernel send buffer.
         int v = 1;
-        if( setsockopt(m_fd, IPPROTO_TCP, TCP_NODELAY, &v, sizeof(v)) == -1 )
+        if( setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &v, sizeof(v)) == -1 )
             throw_unix_error(errno, "setsockopt(TCP_NODELAY)");
     }
     void free_buffers();

--- a/src/counter/sockets.cpp
+++ b/src/counter/sockets.cpp
@@ -24,6 +24,9 @@ counter_socket::counter_socket(int fd,
     g_stats.total_connections.fetch_add(1);
 
     m_recvjob = [this](cybozu::dynbuf& buf) {
+        int fd = fileno();
+        if( fd == -1 ) return;
+
         // load pending data
         if( ! m_pending.empty() ) {
             buf.append(m_pending.data(), m_pending.size());
@@ -32,7 +35,7 @@ counter_socket::counter_socket(int fd,
 
         while( true ) {
             char* p = buf.prepare(MAX_RECVSIZE);
-            ssize_t n = ::recv(m_fd, p, MAX_RECVSIZE, 0);
+            ssize_t n = ::recv(fd, p, MAX_RECVSIZE, 0);
             if( n == -1 ) {
                 if( errno == EAGAIN || errno == EWOULDBLOCK )
                     break;


### PR DESCRIPTION
Resolves https://github.com/cybozu/yrmcds/issues/93.

`cybozu::resource` now keeps the file descriptor private and adds
a new private method `close()` to close the file descriptor from
the friend class `cybozu::reactor`. Subclasses can get the file
descriptor via `int fileno()` method that returns -1 after the
resource is invalidated.

`cybozu::reactor` calls `cybozu::resource::close` when it removes
the resource from the active set of resources and puts it to the
pending destruction list. By this, the file descriptor of the
invalidated resource is closed earlier.

Other classes are updated to reference `fileno()`.