### PR TITLE
Early close resource file descriptors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
-        compiler: [[gcc, g++], [clang, clang++]]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        compiler: [{cc: gcc, cxx: g++}, {cc: clang, cxx: clang++}]
     timeout-minutes: 30
 
     steps:
@@ -26,8 +26,8 @@ jobs:
         ./yrmcdsd &
         sleep 1
       env:
-        CC: ${{ matrix.compiler[0] }}
-        CXX: ${{ matrix.compiler[1] }}
+        CC: ${{ matrix.compiler.cc }}
+        CXX: ${{ matrix.compiler.cxx }}
     - name: Run tests
       run: |
         make YRMCDS_SERVER=localhost tests

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Editors
 *~
 .*.swp
+.vscode/settings.json
 
 # Directories
 html

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "CACHELINE_SIZE=32"
+            ],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "gnu++17",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Makefile for yrmcds
-# Prerequisites: gcc 4.8+ or clang 3.3+
+# Prerequisites: gcc 11.1+ or clang 14+
 
 PREFIX = /usr/local
 DEFAULT_CONFIG = $(PREFIX)/etc/yrmcds.conf
@@ -17,7 +17,7 @@ OPTFLAGS = -O2 #-flto
 DEBUGFLAGS = -gdwarf-3 #-fsanitize=address
 WARNFLAGS = -Wall -Wnon-virtual-dtor -Woverloaded-virtual
 CPUFLAGS = #-march=core2 -mtune=corei7
-CXXFLAGS = -std=gnu++11 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS)
+CXXFLAGS = -std=gnu++17 $(OPTFLAGS) $(DEBUGFLAGS) $(shell getconf LFS_CFLAGS) $(WARNFLAGS) $(CPUFLAGS)
 LDFLAGS = -L. $(shell getconf LFS_LDFLAGS)
 LDLIBS = $(shell getconf LFS_LIBS) -lyrmcds $(LIBTCMALLOC) -latomic -lpthread
 

--- a/cybozu/reactor.cpp
+++ b/cybozu/reactor.cpp
@@ -16,7 +16,7 @@ const int POLLING_TIMEOUT = 100; // milli seconds
 
 namespace cybozu {
 
-void resource::invalidate_and_close() {
+void resource::invalidate_and_close_() {
     bool expected = true;
     if( ! m_valid.compare_exchange_strong(expected, false) )
         return;

--- a/cybozu/reactor.hpp
+++ b/cybozu/reactor.hpp
@@ -15,7 +15,6 @@
 #include <sys/epoll.h>
 #include <unistd.h>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 // hack the pthread_rwlock initializer to avoid writer starvation
@@ -152,7 +151,7 @@ protected:
         if( ! valid() ) return false;
         // no need to check m_closed because it becomes true only after m_valid is set to false.
 
-        if( std::forward<Func>(f)(m_fd) ) {
+        if( f(m_fd) ) {
             return true;
         }
 

--- a/cybozu/reactor.hpp
+++ b/cybozu/reactor.hpp
@@ -288,6 +288,10 @@ public:
     // When such a thread successfully invalidates a resource, the thread
     // need to request the reactor thread to remove the resource by
     // calling this.
+    //
+    // Note that the use of `m_fd` here does not initiate any new syscalls.
+    // The value is used just as a map key to find the resource to remove
+    // from the reactor. So, no read-lock for `m_fd` is necessary.
     void request_removal(const resource& res) {
         lock_guard g(m_lock);
         m_drop_req.push_back(res.m_fd);

--- a/cybozu/tcp.hpp
+++ b/cybozu/tcp.hpp
@@ -4,6 +4,7 @@
 #ifndef CYBOZU_TCP_HPP
 #define CYBOZU_TCP_HPP
 
+#include "dynbuf.hpp"
 #include "ip_address.hpp"
 #include "reactor.hpp"
 #include "util.hpp"
@@ -86,12 +87,14 @@ public:
     //
     // @return `true` if this socket is valid, `false` otherwise.
     bool send(const char* p, std::size_t len, bool flush=false) {
-        lock_guard g(m_lock);
-        if( ! _send(p, len, g) )
-            return false;
-        if( flush && empty() )
-            _flush();
-        return true;
+        return with_fd([=](int fd) -> bool {
+            lock_guard g(m_lock);
+            if( ! _send(fd, p, len, g) )
+                return false;
+            if( flush && empty() )
+                _flush(fd);
+            return true;
+        });
     }
 
     // Atomically send multiple data.
@@ -104,14 +107,16 @@ public:
     //
     // @return `true` if this socket is valid, `false` otherwise.
     bool sendv(const iovec* iov, int iovcnt, bool flush=false) {
-        if( iovcnt >= MAX_IOVCNT )
-            throw std::logic_error("<tcp_socket::sendv> too many iovec.");
-        lock_guard g(m_lock);
-        if( ! _sendv(iov, iovcnt, g) )
-            return false;
-        if( flush && empty() )
-            _flush();
-        return true;
+        return with_fd([=](int fd) -> bool {
+            if( iovcnt >= MAX_IOVCNT )
+                throw std::logic_error("<tcp_socket::sendv> too many iovec.");
+            lock_guard g(m_lock);
+            if( ! _sendv(fd, iov, iovcnt, g) )
+                return false;
+            if( flush && empty() )
+                _flush(fd);
+            return true;
+        });
     }
 
     // Atomically send data, then close the socket.
@@ -124,19 +129,19 @@ public:
     //
     // @return `true` if this socket is valid, `false` otherwise.
     bool send_close(const char* p, std::size_t len) {
-        lock_guard g(m_lock);
-        if( ! _send(p, len, g) )
-            return false;
-        m_shutdown = true;
-        if( empty() ) {
-            _flush();
+        return with_fd([=](int fd) -> bool {
+            lock_guard g(m_lock);
+            if( ! _send(fd, p, len, g) )
+                return false;
+            m_shutdown = true;
+            if( empty() ) {
+                _flush(fd);
+                return false;
+            }
             g.unlock();
-            invalidate_and_close();
+            m_cond_write.notify_all();
             return true;
-        }
-        g.unlock();
-        m_cond_write.notify_all();
-        return true;
+        });
     }
 
     // Atomically send multiple data, then close the socket.
@@ -149,21 +154,65 @@ public:
     //
     // @return `true` if this socket is valid, `false` otherwise.
     bool sendv_close(const iovec* iov, int iovcnt) {
-        if( iovcnt >= MAX_IOVCNT )
-            throw std::logic_error("<tcp_socket::sendv> too many iov.");
-        lock_guard g(m_lock);
-        if( ! _sendv(iov, iovcnt, g) )
-            return false;
-        m_shutdown = true;
-        if( empty() ) {
-            _flush();
+        return with_fd([=](int fd) -> bool {
+            if( iovcnt >= MAX_IOVCNT )
+                throw std::logic_error("<tcp_socket::sendv> too many iov.");
+            lock_guard g(m_lock);
+            if( ! _sendv(fd, iov, iovcnt, g) )
+                return false;
+            m_shutdown = true;
+            if( empty() ) {
+                _flush(fd);
+                return false;
+            }
             g.unlock();
-            invalidate_and_close();
+            m_cond_write.notify_all();
             return true;
+        });
+    }
+
+    enum class recv_result {
+        OK,    // Received some data.
+        AGAIN, // No data was available.
+        RESET, // Connection reset by peer.
+        NONE,  // Peer half-closed the connection.
+    };
+
+    // Receive data from the socket.
+    // @buf           A buffer to store received data.
+    // @max_recvsize  Maximum size of data to be received.
+    //
+    // This function receives data from the socket.  Since this uses `with_fd`
+    // internally, the reactor thread should not call this, or it may be blocked.
+    //
+    // @return The result of the operation.
+    recv_result recv(dynbuf& buf, const std::size_t max_recvsize) {
+        char* p = buf.prepare(max_recvsize);
+        ::ssize_t n;
+        auto ret = with_fd([=, &n](int fd) -> bool {
+            do {
+                n = ::recv(fd, p, max_recvsize, 0);
+            } while( n == -1 && errno == EINTR );
+
+            return (n != -1) || (errno != ECONNRESET);
+        });
+
+        if( ! ret ) {
+            return recv_result::RESET;
         }
-        g.unlock();
-        m_cond_write.notify_all();
-        return true;
+
+        if( n == 0 ) {
+            return recv_result::NONE;
+        }
+
+        if( n == -1 ) {
+            if( errno == EAGAIN || errno == EWOULDBLOCK )
+                return recv_result::AGAIN;
+            throw_unix_error(errno, "recv");
+        }
+
+        buf.consume(n);
+        return recv_result::OK;
     }
 
 protected:
@@ -172,20 +221,20 @@ protected:
     // This method tries to send pending data as much as possible.
     //
     // @return `false` if some error happened, `true` otherwise.
-    bool write_pending_data();
+    bool write_pending_data(int fd);
 
     // Just call <write_pending_data>.
     //
     // The default implementation just invoke <write_pending_data>.
     // You may override this to dispatch the job to another thread.
-    virtual bool on_writable() override {
-        if( write_pending_data() )
+    virtual bool on_writable(int fd) override {
+        if( write_pending_data(fd) )
             return true;
         return invalidate();
     }
 
-    virtual void on_invalidate() override {
-        ::shutdown(m_fd, SHUT_RDWR);
+    virtual void on_invalidate(int fd) override {
+        ::shutdown(fd, SHUT_RDWR);
         free_buffers();
         m_cond_write.notify_all();
     }
@@ -217,16 +266,16 @@ private:
         if( m_pending.empty() ) return true;
         return capacity() >= len;
     }
-    bool _send(const char* p, std::size_t len, lock_guard& g);
-    bool _sendv(const iovec* iov, const int iovcnt, lock_guard& g);
+    bool _send(int fd, const char* p, std::size_t len, lock_guard& g);
+    bool _sendv(int fd, const iovec* iov, const int iovcnt, lock_guard& g);
     bool empty() const {
         return m_pending.empty() && m_tmpbuf.empty();
     }
-    void _flush() {
+    void _flush(int fd) {
         // with TCP_CORK, setting TCP_NODELAY effectively flushes
         // the kernel send buffer.
         int v = 1;
-        if( setsockopt(m_fd, IPPROTO_TCP, TCP_NODELAY, &v, sizeof(v)) == -1 )
+        if( setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &v, sizeof(v)) == -1 )
             throw_unix_error(errno, "setsockopt(TCP_NODELAY)");
     }
     void free_buffers();
@@ -276,8 +325,8 @@ public:
 private:
     wrapper m_wrapper;
 
-    virtual bool on_readable() override final;
-    virtual bool on_writable() override final { return true; }
+    virtual bool on_readable(int) override final;
+    virtual bool on_writable(int) override final { return true; }
 };
 
 

--- a/cybozu/tcp.hpp
+++ b/cybozu/tcp.hpp
@@ -183,10 +183,10 @@ public:
     // @max_recvsize  Maximum size of data to be received.
     //
     // This function receives data from the socket.  Since this uses `with_fd`
-    // internally, the reactor thread should not call this, or it may be blocked.
+    // internally, the reactor thread should not call this.
     //
     // @return The result of the operation.
-    recv_result recv(dynbuf& buf, const std::size_t max_recvsize) {
+    recv_result receive(dynbuf& buf, const std::size_t max_recvsize) {
         char* p = buf.prepare(max_recvsize);
         ::ssize_t n;
         auto ret = with_fd([=, &n](int fd) -> bool {

--- a/src/counter/sockets.cpp
+++ b/src/counter/sockets.cpp
@@ -31,7 +31,7 @@ counter_socket::counter_socket(int fd,
         }
 
         while( true ) {
-            auto res = recv(buf, MAX_RECVSIZE);
+            auto res = receive(buf, MAX_RECVSIZE);
             if( res == recv_result::AGAIN )
                 break;
             if( res == recv_result::RESET || res == recv_result::NONE ) {
@@ -55,7 +55,7 @@ counter_socket::counter_socket(int fd,
                                           << len << " bytes.";
                 buf.reset();
                 release_all();
-                with_fd([](int) -> bool { return false; });
+                invalidate_and_close();
                 break;
             }
             buf.erase(head - buf.data());

--- a/src/counter/sockets.cpp
+++ b/src/counter/sockets.cpp
@@ -31,29 +31,14 @@ counter_socket::counter_socket(int fd,
         }
 
         while( true ) {
-            char* p = buf.prepare(MAX_RECVSIZE);
-            ssize_t n = ::recv(m_fd, p, MAX_RECVSIZE, 0);
-            if( n == -1 ) {
-                if( errno == EAGAIN || errno == EWOULDBLOCK )
-                    break;
-                if( errno == EINTR )
-                    continue;
-                if( errno == ECONNRESET ) {
-                    buf.reset();
-                    release_all();
-                    invalidate_and_close();
-                    break;
-                }
-                cybozu::throw_unix_error(errno, "recv");
-            }
-            if( n == 0 ) {
+            auto res = recv(buf, MAX_RECVSIZE);
+            if( res == recv_result::AGAIN )
+                break;
+            if( res == recv_result::RESET || res == recv_result::NONE ) {
                 buf.reset();
                 release_all();
-                invalidate_and_close();
                 break;
             }
-            // if (n != -1) && (n != 0)
-            buf.consume(n);
 
             const char* head = buf.data();
             std::size_t len = buf.size();
@@ -70,7 +55,7 @@ counter_socket::counter_socket(int fd,
                                           << len << " bytes.";
                 buf.reset();
                 release_all();
-                invalidate_and_close();
+                with_fd([](int) -> bool { return false; });
                 break;
             }
             buf.erase(head - buf.data());
@@ -84,8 +69,9 @@ counter_socket::counter_socket(int fd,
     };
 
     m_sendjob = [this](cybozu::dynbuf& buf) {
-        if( ! write_pending_data() )
-            invalidate_and_close();
+        with_fd([=](int fd) -> bool {
+            return write_pending_data(fd);
+        });
     };
 }
 
@@ -94,7 +80,7 @@ counter_socket::~counter_socket() {
     release_all();
 }
 
-bool counter_socket::on_readable() {
+bool counter_socket::on_readable(int fd) {
     if( m_busy.load(std::memory_order_acquire) ) {
         m_reactor->add_readable(*this);
         return true;
@@ -112,11 +98,11 @@ bool counter_socket::on_readable() {
     return true;
 }
 
-bool counter_socket::on_writable() {
+bool counter_socket::on_writable(int fd) {
     cybozu::worker* w = m_finder();
     if( w == nullptr ) {
         // if there is no idle worker, fallback to the default.
-        return cybozu::tcp_socket::on_writable();
+        return cybozu::tcp_socket::on_writable(fd);
     }
 
     w->post_job(m_sendjob);

--- a/src/counter/sockets.hpp
+++ b/src/counter/sockets.hpp
@@ -42,13 +42,13 @@ private:
     std::unordered_map<const cybozu::hash_key*, std::uint32_t>
         m_acquired_resources;
 
-    virtual void on_invalidate() override final {
+    virtual void on_invalidate(int fd) override final {
         g_stats.curr_connections.fetch_sub(1);
-        cybozu::tcp_socket::on_invalidate();
+        cybozu::tcp_socket::on_invalidate(fd);
     }
 
-    bool on_readable() override;
-    bool on_writable() override;
+    bool on_readable(int) override;
+    bool on_writable(int) override;
 
     void cmd_get(const counter::request& cmd, counter::response& r);
     void cmd_acquire(const counter::request& cmd, counter::response& r);

--- a/src/memcache/handler.cpp
+++ b/src/memcache/handler.cpp
@@ -114,14 +114,10 @@ void handler::on_master_interval() {
             continue;
         }
         if( slave->timed_out() ) {
-            std::string addr = "unknown address";
-            try {
-                addr = cybozu::get_peer_ip_address(slave->fileno()).str();
-            } catch (...) {
-                // ignore errors
-            }
-            cybozu::logger::info() << "No heartbeats from a slave (" << addr
-                                   << "). Close the replication socket.";
+            cybozu::logger::info()
+                << "No heartbeats from a slave ("
+                << slave->peer_ip()
+                << "). Close the replication socket.";
             // close the socket and release resources
             if( ! slave->invalidate() )
                 m_reactor.remove_resource(*slave);

--- a/src/memcache/memcache.cpp
+++ b/src/memcache/memcache.cpp
@@ -58,7 +58,7 @@ inline UInt to_uint(const char* p, bool& result) {
         errno == ERANGE ) return 0;
     char c = *end;
     if( c != CR && c != LF && c != SP ) return 0;
-    if( i > std::numeric_limits<UInt>::max() ) return 0;
+    if( i > static_cast<unsigned long long>(std::numeric_limits<UInt>::max()) ) return 0;
     result = true;
     return static_cast<UInt>(i);
 }

--- a/src/memcache/memcache.cpp
+++ b/src/memcache/memcache.cpp
@@ -50,6 +50,8 @@ inline const char* cfind(const char* p, char c, std::size_t len) {
 
 template<typename UInt>
 inline UInt to_uint(const char* p, bool& result) {
+    static_assert( sizeof(UInt) <= sizeof(unsigned long long),
+                   "UInt is larger than unsigned long long" );
     result = false;
     char* end;
     unsigned long long i = strtoull(p, &end, 10);

--- a/src/memcache/sockets.cpp
+++ b/src/memcache/sockets.cpp
@@ -44,7 +44,10 @@ memcache_socket::memcache_socket(int fd,
 
     m_recvjob = [this](cybozu::dynbuf& buf) {
         // set lock context for objects.
-        g_context = m_fd;
+        with_fd([](int fd) -> bool {
+            g_context = fd;
+            return true;
+        });
 
         // load pending data
         if( ! m_pending.empty() ) {
@@ -53,29 +56,14 @@ memcache_socket::memcache_socket(int fd,
         }
 
         while( true ) {
-            char* p = buf.prepare(MAX_RECVSIZE);
-            ssize_t n = ::recv(m_fd, p, MAX_RECVSIZE, 0);
-            if( n == -1 ) {
-                if( errno == EAGAIN || errno == EWOULDBLOCK )
-                    break;
-                if( errno == EINTR )
-                    continue;
-                if( errno == ECONNRESET ) {
-                    buf.reset();
-                    unlock_all();
-                    invalidate_and_close();
-                    break;
-                }
-                cybozu::throw_unix_error(errno, "recv");
-            }
-            if( n == 0 ) {
+            auto res = recv(buf, MAX_RECVSIZE);
+            if( res == recv_result::AGAIN )
+                break;
+            if( res == recv_result::RESET || res == recv_result::NONE ) {
                 buf.reset();
                 unlock_all();
-                invalidate_and_close();
                 break;
             }
-            // if (n != -1) && (n != 0)
-            buf.consume(n);
 
             const char* head = buf.data();
             std::size_t len = buf.size();
@@ -101,7 +89,7 @@ memcache_socket::memcache_socket(int fd,
                                           << len << " bytes.";
                 buf.reset();
                 unlock_all();
-                invalidate_and_close();
+                with_fd([](int) -> bool { return false; });
                 break;
             }
             buf.erase(head - buf.data());
@@ -115,8 +103,9 @@ memcache_socket::memcache_socket(int fd,
     };
 
     m_sendjob = [this](cybozu::dynbuf&) {
-        if( ! write_pending_data() )
-            invalidate_and_close();
+        with_fd([=](int fd) -> bool {
+            return write_pending_data(fd);
+        });
     };
 }
 
@@ -131,7 +120,7 @@ memcache_socket::~memcache_socket() {
     }
 }
 
-bool memcache_socket::on_readable() {
+bool memcache_socket::on_readable(int) {
     if( m_busy.load(std::memory_order_acquire) ) {
         m_reactor->add_readable(*this);
         return true;
@@ -152,11 +141,11 @@ bool memcache_socket::on_readable() {
     return true;
 }
 
-bool memcache_socket::on_writable() {
+bool memcache_socket::on_writable(int fd) {
     cybozu::worker* w = m_finder();
     if( w == nullptr ) {
         // if there is no idle worker, fallback to the default.
-        return cybozu::tcp_socket::on_writable();
+        return cybozu::tcp_socket::on_writable(fd);
     }
 
     w->post_job(m_sendjob);
@@ -556,7 +545,7 @@ void memcache_socket::cmd_bin(const memcache::binary_request& cmd) {
     case binary_command::QuitQ:
         unlock_all();
         if( cmd.quiet() ) {
-            invalidate_and_close();
+            with_fd([](int) -> bool { return false; });
         } else {
             r.quit();
         }
@@ -947,7 +936,7 @@ void memcache_socket::cmd_text(const memcache::text_request& cmd) {
         break;
     case text_command::QUIT:
         unlock_all();
-        invalidate_and_close();
+        with_fd([](int) -> bool { return false; });
         break;
     default:
         cybozu::logger::info() << "not implemented";
@@ -955,10 +944,10 @@ void memcache_socket::cmd_text(const memcache::text_request& cmd) {
     }
 }
 
-bool repl_socket::on_readable() {
+bool repl_socket::on_readable(int fd) {
     // recv and drop.
     while( true ) {
-        ssize_t n = ::recv(m_fd, &m_recvbuf[0], MAX_RECVSIZE, 0);
+        ssize_t n = ::recv(fd, &m_recvbuf[0], MAX_RECVSIZE, 0);
         if( n == -1 ) {
             if( errno == EAGAIN || errno == EWOULDBLOCK )
                 break;
@@ -967,7 +956,7 @@ bool repl_socket::on_readable() {
             if( errno == ECONNRESET ) {
                 std::string addr = "unknown address";
                 try {
-                    addr = cybozu::get_peer_ip_address(m_fd).str();
+                    addr = cybozu::get_peer_ip_address(fd).str();
                 } catch (...) {
                     // ignore errors
                 }
@@ -979,7 +968,7 @@ bool repl_socket::on_readable() {
         if( n == 0 ) {
             std::string addr = "unknown address";
             try {
-                addr = cybozu::get_peer_ip_address(m_fd).str();
+                addr = cybozu::get_peer_ip_address(fd).str();
             } catch (...) {
                 // ignore errors
             }
@@ -991,18 +980,18 @@ bool repl_socket::on_readable() {
     return true;
 }
 
-bool repl_socket::on_writable() {
+bool repl_socket::on_writable(int fd) {
     cybozu::worker* w = m_finder();
     if( w == nullptr ) {
         // if there is no idle worker, fallback to the default.
-        return cybozu::tcp_socket::on_writable();
+        return cybozu::tcp_socket::on_writable(fd);
     }
 
     w->post_job(m_sendjob);
     return true;
 }
 
-bool repl_client_socket::on_readable() {
+bool repl_client_socket::on_readable(int fd) {
     // This function is executed in the same thread as the function that sends
     // heartbeats. If this function takes a very long time, no heartbeats will
     // be sent, and this process will be judged dead by the master. To prevent
@@ -1012,7 +1001,7 @@ bool repl_client_socket::on_readable() {
     size_t n_iter = 0;
     while( true ) {
         char* p = m_recvbuf.prepare(MAX_RECVSIZE);
-        ssize_t n = ::recv(m_fd, p, MAX_RECVSIZE, 0);
+        ssize_t n = ::recv(fd, p, MAX_RECVSIZE, 0);
         if( n == -1 ) {
             if( errno == EAGAIN || errno == EWOULDBLOCK )
                 break;

--- a/test/tcp.cpp
+++ b/test/tcp.cpp
@@ -38,7 +38,7 @@ AUTOTEST(fd_exhausted) {
 
         struct dummy_socket : public cybozu::tcp_socket {
             dummy_socket(int s): cybozu::tcp_socket(s) {}
-            virtual bool on_readable() override { return true; }
+            virtual bool on_readable(int) override { return true; }
         };
         auto on_accept = [](int s, const cybozu::ip_address addr) {
             return std::unique_ptr<cybozu::tcp_socket>(new dummy_socket(s));


### PR DESCRIPTION
Previously, the file descriptor in a `cybozu::resource` remained open
throughout its lifetime, so it was unnecessary to protect references
to such a file descriptor. However, this sometimes caused out of
file descriptors error due to its late closing.

This PR introduces a new API design around `cybozu::resource` so that
the reactor can close file descriptors earlier than before.

The new API design consists of the following notable changes:
- `cybozu::resource::m_fd` is now a private member, so no direct reference is allowed.
- `cybozu::resource` holds a readers-writer lock to protect `m_fd`.
- Subclasses should use `resource::with_fd` to get the file descriptor along with a reader lock.
- The reactor thread tries to close the file descriptor early only if it can get a writer lock.

Resolve: #93 