### PR TITLE
reactor: eager close of resource fds in the pending destruction list

### DIFF
--- a/cybozu/reactor.hpp
+++ b/cybozu/reactor.hpp
@@ -315,6 +315,11 @@ public:
 
         logger::debug() << "reactor: collecting " << n << " resources.";
         m_garbage_copy.swap(m_garbage);
+
+        // eagerly close the file descriptors before gc() is called.
+        for( auto& res: m_garbage_copy )
+            res->try_close();
+
         return true;
     }
 


### PR DESCRIPTION
The file descriptor of a resource in the pending destruction list
may not be closed. This commit closes them when the list is fixed
for the next GC, adding more chance to close file descritors early.
