### PR TITLE
Prevent slave data delete when unable to connect to master

### DIFF
--- a/src/counter/handler.cpp
+++ b/src/counter/handler.cpp
@@ -83,6 +83,10 @@ void handler::on_master_end() {
     m_gc_thread = nullptr; // join
 }
 
+bool handler::on_slave_start() {
+    clear();
+}
+
 void handler::dump_stats() {
     std::uint64_t ops = 0;
     for( auto& v: g_stats.ops ) {

--- a/src/counter/handler.cpp
+++ b/src/counter/handler.cpp
@@ -85,6 +85,7 @@ void handler::on_master_end() {
 
 bool handler::on_slave_start() {
     clear();
+    return true;
 }
 
 void handler::dump_stats() {

--- a/src/counter/handler.hpp
+++ b/src/counter/handler.hpp
@@ -24,10 +24,11 @@ public:
     virtual void on_master_start() override;
     virtual void on_master_interval() override;
     virtual void on_master_end() override;
+    virtual bool on_slave_start() override;
     virtual void dump_stats() override;
-    virtual void clear() override;
 
 private:
+    void clear();
     bool gc_ready();
     std::unique_ptr<cybozu::tcp_socket> make_counter_socket(int s);
 

--- a/src/handler.hpp
+++ b/src/handler.hpp
@@ -45,9 +45,6 @@ public:
     // Implementations should use `cybozu::logger::info()` to emit stats.
     virtual void dump_stats() = 0;
 
-    // Called when the server discards all stored data.
-    virtual void clear() {}
-
     // If this protocol handler is ready for the reactor GC,
     // returns true. Otherwise, return false.
     virtual bool reactor_gc_ready() const { return true; }

--- a/src/memcache/handler.cpp
+++ b/src/memcache/handler.cpp
@@ -147,6 +147,11 @@ bool handler::on_slave_start() {
         m_reactor.run_once();
         return false;
     }
+
+    // on_slave_start may be called multiple times over the lifetime.
+    // Therefore we need to clear the hash table.
+    clear();
+
     m_repl_client_socket = new repl_client_socket(fd, m_hash);
     m_reactor.add_resource(std::unique_ptr<cybozu::resource>(m_repl_client_socket),
                            cybozu::reactor::EVENT_IN|cybozu::reactor::EVENT_OUT );

--- a/src/memcache/handler.hpp
+++ b/src/memcache/handler.hpp
@@ -31,10 +31,10 @@ public:
     virtual void on_slave_end() override;
     virtual void on_slave_interval() override;
     virtual void dump_stats() override;
-    virtual void clear() override;
     virtual bool reactor_gc_ready() const override;
 
 private:
+    void clear();
     bool gc_ready(std::time_t now);
     std::unique_ptr<cybozu::tcp_socket> make_memcache_socket(int s);
     std::unique_ptr<cybozu::tcp_socket> make_repl_socket(int s);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -73,9 +73,6 @@ void server::serve() {
     if( is_master() )
         goto MASTER_ENTRY;
     while( true ) {
-        for( auto& handler: m_handlers )
-            handler->clear();
-
         serve_slave();
         if( m_signaled ) return;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -77,12 +77,10 @@ void server::serve() {
         if( m_signaled ) return;
 
         // disconnected from the master
+        cybozu::logger::info() << "Try to promote to master...";
         for( int i = 0; i < MASTER_CHECKS; ++i ) {
             if( is_master() )
                 goto MASTER_ENTRY;
-            cybozu::logger::info()
-                << "The conditions for becoming master are not met. Sleep and retry... ("
-                << i << "/" << MASTER_CHECKS << ")";
             std::this_thread::sleep_for( std::chrono::milliseconds(100) );
         }
         cybozu::logger::warning() << "Could not promote to master. Join the cluster again as a slave.";


### PR DESCRIPTION
This PR extracts bug-fix commits from #90.

These commits fixes the following issues:

> 1. When a slave node disconnected from master longer than 5 seconds, it clears all data it stores. That is, when a leader election takes more than 5 seconds, all data are lost.
> 2. When an error occurred in a name resolution in `tcp_connect`, yrmcds crushes without retry. This is an issue because we use dynamically created/updated `Service` resources to connect to the master node on Kubernetes cluster.
> 3. When slave cannot to promote to the master, yrmcds outputs too many logs, which are not useful.